### PR TITLE
Lock typescript 3.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,6 @@
   },
   "devDependencies": {
     "@types/object-hash": "^1.3.1",
-    "typescript": "^3.8.3"
+    "typescript": "3.8.3"
   }
 }


### PR DESCRIPTION
It would appear typescript 3.9 has introduced some breaking changes as mentioned here (https://github.com/graphql-nexus/nexus-schema-plugin-prisma/issues/664).
Lock typescript on version 3.8 perhaps?