### PR TITLE
Make nexus a dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,10 +41,10 @@
   "dependencies": {
     "graphql-middleware": "^4.0.2",
     "graphql-shield": "^7.3.0",
-    "nexus": "^0.23.0"
   },
   "devDependencies": {
     "@types/object-hash": "^1.3.1",
-    "typescript": "^3.8.3"
+    "nexus": "^0.25.0",
+    "typescript": "^3.8.3",
   }
 }


### PR DESCRIPTION
This plugin uses `nexus@^0.23.0` as a normal dependency, but nexus `0.25.0` is already out. Because of this people who use the latest version of nexus will have nexus two times in their node_modules (0.23.0 and 0.25.0).

The nexus-plugin-prisma also puts `nexus` in their dev dependencies, so it should be fine.